### PR TITLE
fix: add equal 0 condition to least square method section

### DIFF
--- a/src/interpolation-methods/interpolation-methods.tex
+++ b/src/interpolation-methods/interpolation-methods.tex
@@ -52,7 +52,7 @@ $S$を最小にする条件は,
 \begin{equation}
     \sum_{i=1}^{n}
     \frac{[f_{i} - \sum_{j=1}^{n} x_{j} \phi_{j}(t_{i})]\phi_{k}(t_{i})}
-    {\sigma_{i}^{2}},
+    {\sigma_{i}^{2}} = 0,
     ~~~~
     k = 1,2,\ldots,m
     \label{Eq:LSM-Minimum-Condition1}


### PR DESCRIPTION
線形最小二乗法の説明の式10番で、Sを最小にする条件の式の辺解から"= 0"の記述が抜けていたため追記しました。
些細なこととは思いますが…